### PR TITLE
Pass extra arguments to perl script

### DIFF
--- a/src/mosestokenizer/tokenizer.py
+++ b/src/mosestokenizer/tokenizer.py
@@ -41,13 +41,13 @@ class MosesTokenizer(ToolWrapper):
     ['Hello', 'World', '!']
     """
 
-    def __init__(self, lang="en", old_version=False):
+    def __init__(self, lang="en", old_version=False, extra=[]):
         self.lang = lang
         program = path.join(
             path.dirname(__file__),
             "tokenizer-" + ("v1.0" if old_version else "v1.1") + ".perl"
         )
-        argv = ["perl", program, "-q", "-l", self.lang]
+        argv = ["perl", program, "-q", "-l", self.lang] + extra
         if not old_version:
             # -b = disable output buffering
             # -a = aggressive hyphen splitting


### PR DESCRIPTION
Constructor has an extra argument which allows to pass a list of arguments for the tokenizer perl script.

This is a more general way of addressing pull request #2.